### PR TITLE
fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The signed certificate is added to the `.status.certificate` of the `CSR` resour
 
 # Installation
 
-`signer-ca` can be deployed using `kubectl -k config/default`.
+`signer-ca` can be deployed using `kubectl apply -k config/default`.
 See `config/e2e` for an example of how to make a `CA` file available to the operator, as a mounted secret.
 
 # Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # signer-ca
 
+
 `signer-ca` is an operator for automatically signing an *approved* [CertificateSigningRequest](https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/#create-a-certificate-signing-request-object-to-send-to-the-kubernetes-api).
 
 **NOTE: This operator is EXPERIMENTAL and requires Kubernetes >= 1.18.** It uses [Certificates API Enhancements](https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190607-certificates-api.md) which are only available in Kubernetes >= 1.18.


### PR DESCRIPTION
Installation mentions `kubectl  -k config/default`, it should be `kubectl apply -k config/default`

Signed-off-by: Martijn de Boer <martijn.de.boer@sap.com>